### PR TITLE
PA-1388 work with Fw 9

### DIFF
--- a/Build/getDependencies.win.sh
+++ b/Build/getDependencies.win.sh
@@ -76,7 +76,7 @@ cd -
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Libpalaso_PalasoWin32masterContinuous
 #     clean: false
 #     revision: phonologyAssistant.lastSuccessful
-#     paths: {"L10NSharp.dll"=>"Lib", "L10NSharp.pdb"=>"Lib", "SIL.Core.dll"=>"Lib", "SIL.Core.dll.config"=>"Lib", "SIL.Core.pdb"=>"Lib", "SIL.Windows.Forms.dll"=>"Lib", "SIL.Windows.Forms.dll.config"=>"Lib", "SIL.Windows.Forms.pdb"=>"Lib"}
+#     paths: {"L10NSharp.dll"=>"Lib", "L10NSharp.pdb"=>"Lib", "SIL.Core.dll"=>"Lib", "SIL.Core.dll.config"=>"Lib", "SIL.Core.pdb"=>"Lib", "SIL.Core.Desktop.dll"=>"Lib", "SIL.Core.Desktop.pdb"=>"Lib", "SIL.Windows.Forms.dll"=>"Lib", "SIL.Windows.Forms.dll.config"=>"Lib", "SIL.Windows.Forms.pdb"=>"Lib"}
 #     VCS: https://github.com/sillsdev/libpalaso.git [master]
 
 # make sure output directories exist
@@ -95,6 +95,8 @@ copy_auto https://build.palaso.org/guestAuth/repository/download/Libraries_Icu4c
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Core.dll ../Lib/SIL.Core.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Core.dll.config ../Lib/SIL.Core.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Core.pdb ../Lib/SIL.Core.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Core.Desktop.dll ../Lib/SIL.Core.Desktop.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Core.Desktop.pdb ../Lib/SIL.Desktop.Core.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Lexicon.dll ../Lib/SIL.Lexicon.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Lexicon.pdb ../Lib/SIL.Lexicon.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterContinuous/.lastSuccessful/SIL.Windows.Forms.dll ../Lib/SIL.Windows.Forms.dll

--- a/src/DisablePASplashScreen/app.config
+++ b/src/DisablePASplashScreen/app.config
@@ -1,3 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Pa/Pa.csproj
+++ b/src/Pa/Pa.csproj
@@ -41,6 +41,8 @@
     <ApplicationVersion>3.6.4.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-Windows|AnyCPU' ">
     <OutputPath>..\..\Output\Debug-Windows\</OutputPath>
@@ -173,13 +175,21 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Lib\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Lib\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Lib\SIL.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="SIL.Core.Desktop">
+      <HintPath>..\..\Lib\SIL.Core.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="SIL.LCModel, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="SIL.LCModel.Utils, Version=9.0.0.0, Culture=neutral, processorArchitecture=x86">
@@ -205,6 +215,9 @@
       <Name>System.Drawing</Name>
     </Reference>
     <Reference Include="System.Management" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Windows.Forms">
       <Name>System.Windows.Forms</Name>
@@ -1248,6 +1261,7 @@
     <EmbeddedResource Include="Model\Migration\AddRhymeToDistribution.xslt" />
     <EmbeddedResource Include="Model\Migration\UpdatePaUI0350.xslt" />
     <EmbeddedResource Include="Model\Migration\UpdatePaUI0351.xslt" />
+    <None Include="icu4c.readme.txt" />
     <Content Include="Ionic.Zip.xml" />
     <Content Include="pa.ico" />
     <None Include="Resources\CloseTab.png" />
@@ -1324,10 +1338,17 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(HelpFile)" DestinationFiles="@(HelpFile->'$(TargetDir)\%(Filename)%(Extension)')" />
-	<Copy SourceFiles="@(IcuFile)" DestinationFolder="$(TargetDir)" Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'x64'" />
+    <Copy SourceFiles="@(IcuFile)" DestinationFolder="$(TargetDir)" Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'x64'" />
   </Target>
   <ItemGroup>
     <HelpFile Include="$(SolutionDir)\DistFiles\*.chm" />
-	<IcuFile Include="$(SolutionDir)\Lib\$(Platform)\*.dll" />
+    <IcuFile Include="$(SolutionDir)\Lib\$(Platform)\*.dll" />
   </ItemGroup>
+  <Import Project="..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets" Condition="Exists('..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets'))" />
+  </Target>
 </Project>

--- a/src/Pa/UI/Dialogs/ProjectSetup/Fw7DataSourcePropertiesDlg.cs
+++ b/src/Pa/UI/Dialogs/ProjectSetup/Fw7DataSourcePropertiesDlg.cs
@@ -344,7 +344,7 @@ namespace SIL.Pa.UI.Dialogs
 
             // Find the phonetic writing system for the one selected by the user.
             var ws = m_datasource.FwDataSourceInfo.GetWritingSystems()
-                .Single(w => w.Name == cboPhoneticWritingSystem.SelectedItem as string);
+                .First(w => w.Name == cboPhoneticWritingSystem.SelectedItem as string);
 
             m_phoneticMapping.FwWsId = ws.Id;
 

--- a/src/Pa/app.config
+++ b/src/Pa/app.config
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="SIL.Pa.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+            <section name="SIL.Pa.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="SIL.Pa.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+            <section name="SIL.Pa.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <userSettings>
@@ -445,8 +445,7 @@
             <setting name="RTFRecordViewUseExactLineSpacing" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="RTFRecordViewPercentageOfExactLineHeightToUse"
-                serializeAs="String">
+            <setting name="RTFRecordViewPercentageOfExactLineHeightToUse" serializeAs="String">
                 <value>1</value>
             </setting>
             <setting name="SearchOptionsDropDownPickerLabelFontSize" serializeAs="String">
@@ -470,8 +469,7 @@
             <setting name="SearchResultTabActiveIninactiveGroup2" serializeAs="String">
                 <value>215, 209, 196</value>
             </setting>
-            <setting name="SearchResultTabActiveIninactiveGroupForeColor"
-                serializeAs="String">
+            <setting name="SearchResultTabActiveIninactiveGroupForeColor" serializeAs="String">
                 <value>Black</value>
             </setting>
             <setting name="SearchResultTabActiveBackColor" serializeAs="String">
@@ -501,12 +499,10 @@
             <setting name="DistChartVwPlaybackSpeed" serializeAs="String">
                 <value>100</value>
             </setting>
-            <setting name="DefineDescriptiveFeatureClassDlgUseCompactConsonantView"
-                serializeAs="String">
+            <setting name="DefineDescriptiveFeatureClassDlgUseCompactConsonantView" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="DefineDescriptiveFeatureClassDlgUseCompactVowelView"
-                serializeAs="String">
+            <setting name="DefineDescriptiveFeatureClassDlgUseCompactVowelView" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="GridSelectedRowFocusedRectColor" serializeAs="String">
@@ -602,12 +598,10 @@
             <setting name="DefineDistinctiveFeatureClassDlgSplit2Loc" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="DefineDistinctiveFeatureClassDlgUseCompactConsonantView"
-                serializeAs="String">
+            <setting name="DefineDistinctiveFeatureClassDlgUseCompactConsonantView" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="DefineDistinctiveFeatureClassDlgUseCompactVowelView"
-                serializeAs="String">
+            <setting name="DefineDistinctiveFeatureClassDlgUseCompactVowelView" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="IncludeDataSourceFilesInPaBackups" serializeAs="String">
@@ -637,8 +631,7 @@
             <setting name="OpenProjectsInNewWindowCheckedValue" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="AutoCreateProjectFilesAndFolderOnProjectCreation"
-                serializeAs="String">
+            <setting name="AutoCreateProjectFilesAndFolderOnProjectCreation" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="ShowFullProjectFilePathsInOpenDlg" serializeAs="String">
@@ -707,8 +700,7 @@
             </setting>
             <setting name="DefaultMappedFw7Fields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Gloss</string>
                         <string>Phonetic</string>
                         <string>CitationForm</string>
@@ -719,8 +711,7 @@
             </setting>
             <setting name="ParsedFw7Fields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>CV-Pattern-Source</string>
                         <string>Tone</string>
@@ -735,8 +726,7 @@
             </setting>
             <setting name="DefaultVisibleFields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Gloss</string>
                         <string>PartOfSpeech</string>
@@ -747,8 +737,7 @@
             </setting>
             <setting name="DefaultSaFields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Phonemic</string>
                         <string>Tone</string>
@@ -773,8 +762,7 @@
             </setting>
             <setting name="DefaultSfmFields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Reference</string>
                         <string>Phonetic</string>
                         <string>Gloss</string>
@@ -789,8 +777,7 @@
             </setting>
             <setting name="DefaultFw7Fields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>CitationForm</string>
                         <string>LexemeForm</string>
                         <string>MorphType</string>
@@ -849,8 +836,7 @@
             </setting>
             <setting name="AllPossibleFw6Fields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Phonemic</string>
                         <string>Orthographic</string>
@@ -868,8 +854,7 @@
             </setting>
             <setting name="DefaultMappedFw6Fields" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Gloss</string>
                         <string>PartOfSpeech</string>
@@ -883,8 +868,7 @@
             </setting>
             <setting name="Fw6FieldsMappableInPropsDlg" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Phonemic</string>
                         <string>Orthographic</string>
@@ -903,8 +887,7 @@
             </setting>
             <setting name="DefaultVisibleFieldsForNewProject" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                         <string>Phonetic</string>
                         <string>Gloss</string>
                         <string>CitationForm</string>
@@ -917,4 +900,17 @@
             </setting>
         </SIL.Pa.Properties.Settings>
     </applicationSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Pa/icu4c.readme.txt
+++ b/src/Pa/icu4c.readme.txt
@@ -1,0 +1,3 @@
+ICU4C for Windows
+
+This is a dummy file to force nuget to add this package to the project rather than the solution.

--- a/src/Pa/packages.config
+++ b/src/Pa/packages.config
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net461" />
 </packages>

--- a/src/PaTests/PaTests.csproj
+++ b/src/PaTests/PaTests.csproj
@@ -95,6 +95,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\pathway\lib\SIL.Core.dll</HintPath>
     </Reference>
+    <Reference Include="SIL.Core.Desktop, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Lib\SIL.Core.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/src/PaTests/app.config
+++ b/src/PaTests/app.config
@@ -6,6 +6,14 @@
         <assemblyIdentity name="Ionic.Zip" publicKeyToken="edbe51ad942a3f5c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.1.5" newVersion="1.9.1.5" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/PaToFdoInterfaces/PaObjects/PaLexSense.cs
+++ b/src/PaToFdoInterfaces/PaObjects/PaLexSense.cs
@@ -37,7 +37,7 @@ namespace SIL.PaToFdoInterfaces
 			xRestrictions = PaMultiString.Create(lxSense.Restrictions, svcloc);
 			xSemanticsNote = PaMultiString.Create(lxSense.SemanticsNote, svcloc);
 			xSociolinguisticsNote = PaMultiString.Create(lxSense.SocioLinguisticsNote, svcloc);
-			xReversalEntries = lxSense.ReversalEntriesRC.Select(x => PaMultiString.Create(x.ReversalForm, svcloc)).ToList();
+			xReversalEntries = lxSense.ReferringReversalIndexEntries.Select(x => PaMultiString.Create(x.ReversalForm, svcloc)).ToList();
 			xGuid = lxSense.Guid;
 
 			ImportResidue = lxSense.ImportResidue.Text;


### PR DESCRIPTION
* modify reference to reversal entries according to new api
* modify Fw7 phonetic writing system lookup to handle duplicate names
  (use the first one)
* Upgrade package references to use needed NuGet packages (for liblcm)
* add reference to SIL.Core.Desktop